### PR TITLE
feat: Allow host and port specification via CLI arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,16 @@ A simple command-line chat client using C++ and Boost (Asio/Beast) for WebSocket
     ```bash
     ./main
     ```
-2.  **Configuration:**
-    Currently, the server host and port are hardcoded in `src/main.cpp`:
-    ```cpp
-    std::string host = "localhost";
-    std::string port = "8080"; // Replace with your server's port
+    The client can be run with optional command-line arguments to specify the server host and port:
+    ```bash
+    ./main [host port]
     ```
-    You will need to modify these values and recompile if your server is running on a different address or port.
-3.  **Interacting with the Chat:**
+    - If no arguments are provided, it defaults to connecting to `127.0.0.1` on port `8080`.
+    - For example, to connect to a server at `mychatserver.com` on port `12345`:
+      ```bash
+      ./main mychatserver.com 12345
+      ```
+2.  **Interacting with the Chat:**
     - Once connected, type your message and press Enter to send.
     - Received messages will be displayed with a "Server:" prefix.
     - Type `/quit` and press Enter to disconnect and exit the client.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,20 +3,19 @@
 #include <string>
 // Other necessary includes for main.cpp, if any, but most should be in ChatClient.hpp/cpp
 
-int main() {
-    // Default to localhost and port 8080, but could be configurable
-    // For example, by command-line arguments or user input.
-    std::string host = "127.0.0.1"; // Using 127.0.0.1 explicitly
-    std::string port = "8080";
+int main(int argc, char* argv[]) {
+    std::string host = "127.0.0.1"; // Default host
+    std::string port = "8080";     // Default port
 
-    // Example: Allow overriding host and port from command line arguments
-    // if (argc == 3) {
-    //     host = argv[1];
-    //     port = argv[2];
-    // } else if (argc != 1) {
-    //     std::cerr << "Usage: " << argv[0] << " [host port]" << std::endl;
-    //     return 1;
-    // }
+    if (argc == 3) {
+        host = argv[1];
+        port = argv[2];
+    } else if (argc == 1) {
+        // Use default host and port
+    } else {
+        std::cerr << "Usage: " << argv[0] << " [host port]" << std::endl;
+        return 1;
+    }
 
     try {
         ChatClient client(host, port);


### PR DESCRIPTION
This change modifies the chat client to accept optional command-line arguments for specifying the server host and port.

- If two arguments are provided (host and port), they are used for the connection.
- If no arguments are provided, the client defaults to "127.0.0.1" and "8080".
- If any other number of arguments is provided, a usage message is printed to stderr, and the client exits.

The README.md has been updated to reflect this new usage.